### PR TITLE
fix: スレッドにしっかり参加していないのにボタンの参加状態が変わるバグを修正

### DIFF
--- a/src/components/ThreadList.jsx
+++ b/src/components/ThreadList.jsx
@@ -48,9 +48,7 @@ function ThreadList() {
     fetchThreads();
   }, []);
 
-  const handleJoinClick = async (thread, e) => {
-    e.stopPropagation();
-
+  const handleJoinClick = async (thread) => {
     // 参加済みかどうかを確認
     const isJoined =
       thread.participants && thread.participants.includes(currentUser?.uid);
@@ -61,21 +59,21 @@ function ThreadList() {
     } else {
       // 未参加の場合のみモーダルを表示
       setSelectedThread(thread);
-      try {
-        await joinThread(thread.id, currentUser?.uid);
-        const updatedThreads = await getThreads();
-        setThreads(updatedThreads);
-        onOpen();
-      } catch (error) {
-        console.error('Error joining the thread:', error);
-        // エラー処理
-      }
+      onOpen();
     }
   };
 
-  const handleJoinConfirm = () => {
-    navigate(`/thread/${selectedThread.id}`);
-    onClose();
+  const handleJoinConfirm = async () => {
+    try {
+      await joinThread(selectedThread.id, currentUser?.uid);
+      const updatedThreads = await getThreads();
+      setThreads(updatedThreads);
+      navigate(`/thread/${selectedThread.id}`);
+      onClose();
+    } catch (error) {
+      console.error('Error joining the thread:', error);
+      // エラー処理
+    }
   };
 
   const getTagColor = (tag) => {
@@ -154,7 +152,7 @@ function ThreadList() {
                   </VStack>
 
                   <Button
-                    onClick={(e) => handleJoinClick(thread, e)}
+                    onClick={() => handleJoinClick(thread)}
                     size="lg"
                     bgGradient={
                       thread.participants &&


### PR DESCRIPTION
## 対応する Issue

<!-- 該当の Issue を Close したくない場合は、 `Closes` の文言を削除する。 -->
Closes #36 

## リンク

<!-- 参考にしたサイト等があれば記載する。 -->

## やったこと

- Modalに表示される参加ボタンを押さなくても、ThreadListに表示されているボタンの参加状態が変わるバグを発見
- ThreadListに表示されているボタンを押すだけでは参加状態が変わらず、Modalに表示されるボタンを押して初めてスレッドに参加できるように変更

## やらなかったこと

- 

## ユーザーへの影響

<!-- ユーザーから見て、できるようになったことやできなくなったこと等を記載する。 -->

## 動作確認

### 確認した環境

### 確認したこと
<!-- スクショや動画を貼っても良い。 -->

- 

### 確認しなかった（できなかった）こと

- 

## その他
