### PR TITLE
fix/#33: スレッドへのコメント投稿時に最新のコメントまでスクロールされない問題を修正

### DIFF
--- a/src/components/Thread/ThreadDetail.jsx
+++ b/src/components/Thread/ThreadDetail.jsx
@@ -172,11 +172,12 @@ function ThreadDetail() {
             };
           })
         );
-
         setThread({
           ...threadData,
           comments: commentsWithUserInfo,
         });
+        // コメントが追加されたら最下部までスクロール
+        scrollToBottom();
       }
     } catch (error) {
       // コメントの投稿に失敗したときのエラー処理
@@ -191,7 +192,7 @@ function ThreadDetail() {
 
   // コメントが追加されたら最下部までスクrーる
   const scrollToBottom = () => {
-    commentsEndRef.current?.scrollToBottom({ behavior: 'smooth' });
+    commentsEndRef.current?.scrollIntoView({ behavior: 'smooth' });
   };
 
   const handleDeleteComment = async (comment) => {
@@ -420,7 +421,7 @@ function ThreadDetail() {
         ))}
 
         {/* コメント追加後にスクロール */}
-        <div ref={commentsEndRef} />
+        <Box ref={commentsEndRef} />
 
         <MotionBox
           p={5}


### PR DESCRIPTION
## 対応する Issue

<!-- 該当の Issue を Close したくない場合は、 `Closes` の文言を削除する。 -->
Closes #33 

## リンク

<!-- 参考にしたサイト等があれば記載する。 -->

## やったこと

- 問題点:
   - スレッドに新しいコメントを追加しても、画面が自動的に最新のコメントまでスクロールされない。
- 原因:
   - scrollToBottom 関数内で、commentsEndRef.current が正しくDOM要素を参照できていなかった。また、スクロールのタイミングが適切ではなかった。
- 解決策:
   - ref を設定する要素を div から Chakra UI の Box コンポーネントに変更し、commentsEndRef が Box コンポーネントを直接参照す. 
   るように修正。
   scrollToBottom 関数内で scrollIntoView() メソッドを使用するように修正。
   handleAddComment 関数内で、コメントの追加が完了した直後に scrollToBottom() を呼び出すように修正。

## やらなかったこと

- 

## ユーザーへの影響

<!-- ユーザーから見て、できるようになったことやできなくなったこと等を記載する。 -->

## 動作確認

### 確認した環境

### 確認したこと
<!-- スクショや動画を貼っても良い。 -->

- 

### 確認しなかった（できなかった）こと

- 

## その他
