### PR TITLE
fix: AdminRouteの不要なローディングアニメーションとリダイレクトの問題を解消

### DIFF
--- a/src/components/Admin/AdminRoute.jsx
+++ b/src/components/Admin/AdminRoute.jsx
@@ -1,4 +1,4 @@
-import { Navigate, useLocation } from 'react-router-dom';
+import { Navigate, useLocation, useNavigate } from 'react-router-dom';
 import { PropTypes } from 'prop-types';
 import { useAuth } from '../../context/AuthContext';
 import { useEffect, useState } from 'react';
@@ -8,15 +8,14 @@ import { useAlert } from '../../hooks/useAlert';
 export const AdminRoute = ({ children }) => {
   const { currentUser } = useAuth();
   const location = useLocation();
+  const navigate = useNavigate();
   const { showAlert } = useAlert();
   const [isAdmin, setIsAdmin] = useState(false);
-  const [loading, setLoading] = useState(true);
   const threadId = location.pathname.split('/')[2];
 
   useEffect(() => {
     const checkThreadAdmin = async () => {
       if (!currentUser) {
-        setLoading(false);
         return;
       }
 
@@ -27,21 +26,16 @@ export const AdminRoute = ({ children }) => {
           setIsAdmin(true);
         } else {
           showAlert('このスレッドの管理者権限がありません');
+          navigate(`/thread/${threadId}`);
         }
-        setLoading(false);
       } catch (error) {
         console.error('スレッド管理者チェックエラー:', error);
         showAlert('権限の確認中にエラーが発生しました。');
-        setLoading(false);
       }
     };
 
     checkThreadAdmin();
-  }, [currentUser, threadId, showAlert]);
-
-  if (loading) {
-    return null;
-  }
+  }, [currentUser, threadId, showAlert, navigate]);
 
   if (!currentUser || !isAdmin) {
     return <Navigate to={`/thread/${threadId}`} replace />;


### PR DESCRIPTION
## 対応する Issue

<!-- 該当の Issue を Close したくない場合は、 `Closes` の文言を削除する。 -->
Closes #73 

## リンク

<!-- 参考にしたサイト等があれば記載する。 -->

## やったこと

- このコミットは、管理者権限のないユーザーが`/admin/${threadId}`にアクセスしようとした際に、リダイレクト前にローディングアニメーションが短時間表示される問題に対処します。`useNavigate`を使用し、管理者権限の確認後すぐにリダイレクトを行うことで、不要なローディングアニメーションを削除した。
- また、ThreadDetailコンポーネントも更新され、currentUserがロードされる前にスレッドデータがフェッチされることによる競合状態や潜在的なエラーを防止する。

## やらなかったこと

- 

## ユーザーへの影響

<!-- ユーザーから見て、できるようになったことやできなくなったこと等を記載する。 -->

## 動作確認

### 確認した環境

### 確認したこと
<!-- スクショや動画を貼っても良い。 -->

- 

### 確認しなかった（できなかった）こと

- 

## その他
