### PR TITLE
bug/#115: 画像生成中はイベント作成ボタンを無効にする

### DIFF
--- a/src/components/Thread/Ogiri/CreateOgiriEventModal.jsx
+++ b/src/components/Thread/Ogiri/CreateOgiriEventModal.jsx
@@ -429,7 +429,7 @@ const CreateOgiriEventModal = ({ isOpen, onClose }) => {
                   transition="all 0.3s ease"
                 />
                 <FormHelperText color="whiteAlpha.600">
-                  一人のユーザーが投稿できる回答の最大数
+                  一人のユーザーが投稿できる回答の最大��
                 </FormHelperText>
               </FormControl>
             </MotionBox>
@@ -452,6 +452,17 @@ const CreateOgiriEventModal = ({ isOpen, onClose }) => {
             px={8}
             borderRadius="xl"
             isDisabled={isGenerating}
+            opacity={isGenerating ? 0.5 : 1}
+            cursor={isGenerating ? 'not-allowed' : 'pointer'}
+            _disabled={{
+              bg: 'linear-gradient(135deg, #FF1988 0%, #805AD5 100%)',
+              opacity: 0.5,
+              cursor: 'not-allowed',
+              _hover: {
+                transform: 'none',
+                boxShadow: 'none',
+              },
+            }}
             _hover={{
               transform: 'translateY(-2px)',
               boxShadow: '0 8px 15px -3px rgba(255, 25, 136, 0.3)',
@@ -460,7 +471,7 @@ const CreateOgiriEventModal = ({ isOpen, onClose }) => {
             _active={{ transform: 'scale(0.95)' }}
             leftIcon={<Icon as={FiSend} />}
             initial={{ opacity: 0 }}
-            animate={{ opacity: 1 }}
+            animate={{ opacity: isGenerating ? 0.5 : 1 }}
             transition={{ delay: 0.5 }}
           >
             イベントを作成
@@ -469,7 +480,16 @@ const CreateOgiriEventModal = ({ isOpen, onClose }) => {
             variant="ghost"
             onClick={onClose}
             isDisabled={isGenerating}
+            opacity={isGenerating ? 0.5 : 1}
+            cursor={isGenerating ? 'not-allowed' : 'pointer'}
             color="whiteAlpha.700"
+            _disabled={{
+              opacity: 0.5,
+              cursor: 'not-allowed',
+              _hover: {
+                bg: 'transparent',
+              },
+            }}
             _hover={{
               bg: 'whiteAlpha.100',
               color: 'white',

--- a/src/components/Thread/Ogiri/CreateOgiriEventModal.jsx
+++ b/src/components/Thread/Ogiri/CreateOgiriEventModal.jsx
@@ -451,6 +451,7 @@ const CreateOgiriEventModal = ({ isOpen, onClose }) => {
             fontSize="lg"
             px={8}
             borderRadius="xl"
+            isDisabled={isGenerating}
             _hover={{
               transform: 'translateY(-2px)',
               boxShadow: '0 8px 15px -3px rgba(255, 25, 136, 0.3)',
@@ -467,6 +468,7 @@ const CreateOgiriEventModal = ({ isOpen, onClose }) => {
           <Button
             variant="ghost"
             onClick={onClose}
+            isDisabled={isGenerating}
             color="whiteAlpha.700"
             _hover={{
               bg: 'whiteAlpha.100',


### PR DESCRIPTION
## 対応する Issue

<!-- 該当の Issue を Close したくない場合は、 `Closes` の文言を削除する。 -->
Closes #115 

## リンク

<!-- 参考にしたサイト等があれば記載する。 -->

## やったこと

- 画像生成中はボタンを無効にするように修正
- 視覚的にもボタンが無効になっていることがわかるようにデザインも修正

## やらなかったこと

- 

## ユーザーへの影響

<!-- ユーザーから見て、できるようになったことやできなくなったこと等を記載する。 -->

## 動作確認

### 確認した環境

### 確認したこと
<!-- スクショや動画を貼っても良い。 -->

- 

### 確認しなかった（できなかった）こと

- 

## その他
