### PR TITLE
bug/#116: イベントが既に終了していても参加ボタンが機能している問題を解消

### DIFF
--- a/src/components/Thread/Ogiri/OgiriEvent.jsx
+++ b/src/components/Thread/Ogiri/OgiriEvent.jsx
@@ -333,28 +333,57 @@ const OgiriEvent = ({ event, creator, onJoinEvent, currentUser }) => {
             <Button
               onClick={handleJoinClick}
               isLoading={isLoading}
+              isDisabled={isExpired}
               bgGradient={
-                isParticipating
-                  ? 'linear(to-r, green.400, teal.400)'
-                  : 'linear(to-r, pink.400, purple.400)'
+                isExpired
+                  ? 'linear(to-r, gray.600, gray.700)'
+                  : isParticipating
+                    ? 'linear(to-r, green.400, teal.400)'
+                    : 'linear(to-r, pink.400, purple.400)'
               }
-              color="white"
+              color={isExpired ? 'whiteAlpha.600' : 'white'}
               px={6}
               py={6}
               fontSize="md"
-              rightIcon={<Icon as={isParticipating ? FiCheck : FiArrowRight} />}
+              rightIcon={
+                !isExpired && (
+                  <Icon as={isParticipating ? FiCheck : FiArrowRight} />
+                )
+              }
               _hover={{
-                transform: 'translateY(-2px)',
-                boxShadow: '0 4px 12px rgba(255, 20, 147, 0.3)',
+                transform: isExpired ? 'none' : 'translateY(-2px)',
+                boxShadow: isExpired
+                  ? 'none'
+                  : '0 4px 12px rgba(255, 20, 147, 0.3)',
               }}
               _active={{
-                transform: 'translateY(0)',
+                transform: isExpired ? 'none' : 'translateY(0)',
                 boxShadow: 'none',
+              }}
+              _disabled={{
+                opacity: 0.7,
+                cursor: 'not-allowed',
+                boxShadow: 'none',
+                _hover: {
+                  bg: 'linear(to-r, gray.600, gray.700)',
+                  transform: 'none',
+                },
               }}
               borderRadius="xl"
               transition="all 0.2s"
+              border="1px solid"
+              borderColor={isExpired ? 'gray.600' : 'transparent'}
             >
-              {isParticipating ? '参加中' : '大喜利に参加する'}
+              {isExpired ? (
+                <HStack spacing={2} opacity={0.8}>
+                  <Icon as={FiClock} />
+                  <Text>終了済み</Text>
+                </HStack>
+              ) : isParticipating ? (
+                '参加中'
+              ) : (
+                '大喜利に参加する'
+              )}
             </Button>
           </Flex>
         </Flex>

--- a/src/services/ogiriService.js
+++ b/src/services/ogiriService.js
@@ -59,6 +59,19 @@ export const getOgiriEvents = async (threadId) => {
 export const joinOgiriEvent = async (threadId, eventId, userId) => {
   try {
     const eventRef = doc(db, 'threads', threadId, 'ogiriEvents', eventId);
+    const eventDoc = await getDoc(eventRef);
+    const eventData = eventDoc.data();
+
+    const isExpired = checkEventExpiration({
+      createdAt: eventData.createdAt,
+      duration: eventData.duration,
+      status: eventData.status,
+    });
+
+    if (isExpired) {
+      throw new Error('このイベントは既に終了しています');
+    }
+
     await updateDoc(eventRef, {
       participants: arrayUnion(userId),
     });


### PR DESCRIPTION
## 対応する Issue

<!-- 該当の Issue を Close したくない場合は、 `Closes` の文言を削除する。 -->
Closes #116 

## リンク

<!-- 参考にしたサイト等があれば記載する。 -->

## やったこと

- イベントが終了したら参加ボタンのスタイルをグレーにし、テキストに終了済みと表示させるように修正
- サーバーサイドでも終了したイベントへの参加をブロックし、エラーを返すように修正

## やらなかったこと

- 

## ユーザーへの影響

<!-- ユーザーから見て、できるようになったことやできなくなったこと等を記載する。 -->

## 動作確認

### 確認した環境

### 確認したこと
<!-- スクショや動画を貼っても良い。 -->

- 

### 確認しなかった（できなかった）こと

- 

## その他
