### PR TITLE
fix/#135: ローカルでのstate更新が行われていたので、state更新を削除し、リアルタイムリスナーに一本化するように変更

### DIFF
--- a/src/components/Thread/hooks/useComments.js
+++ b/src/components/Thread/hooks/useComments.js
@@ -1,5 +1,4 @@
 import { useState, useCallback, useEffect } from 'react';
-import { Timestamp } from 'firebase/firestore';
 import {
   addCommentToThread,
   deleteCommentFromThread,
@@ -42,17 +41,6 @@ export const useComments = (threadId, thread, setThread, currentUser) => {
 
       try {
         const { uid: userId, displayName, photoURL } = currentUser;
-        const createdAt = Timestamp.now();
-        const newComment = {
-          id: createdAt.toMillis().toString(),
-          text: commentText,
-          createdAt,
-          createdBy: userId,
-          createdByUsername: displayName,
-          userPhotoURL: photoURL,
-          isAdmin: thread.createdBy === userId,
-          uniqueKey: `${createdAt.toMillis().toString()}-new`,
-        };
 
         await addCommentToThread(
           threadId,
@@ -64,17 +52,12 @@ export const useComments = (threadId, thread, setThread, currentUser) => {
 
         setIsNewCommentAdded(true);
         setError('');
-
-        setThread((prevThread) => ({
-          ...prevThread,
-          comments: [newComment, ...(prevThread.comments || [])],
-        }));
       } catch (error) {
         console.error('Error adding comment:', error);
         setError('コメントの追加中にエラーが発生しました。');
       }
     },
-    [threadId, thread, currentUser, setThread]
+    [threadId, currentUser]
   );
 
   const handleDeleteComment = useCallback(


### PR DESCRIPTION
## 対応する Issue

<!-- 該当の Issue を Close したくない場合は、 `Closes` の文言を削除する。 -->
Closes #135 

## リンク

<!-- 参考にしたサイト等があれば記載する。 -->

## やったこと

- タイトルの通り(詳しくはコミット履歴を参照)

### 修正の理由
-リアルタイムリスナーが既にコメントの追加を監視・反映しているため
- ローカルでのstate更新が重複を引き起こしている
- 一元化された更新管理により、データの整合性が保たれる

## やらなかったこと

- 

## ユーザーへの影響

<!-- ユーザーから見て、できるようになったことやできなくなったこと等を記載する。 -->

## 動作確認

### 確認した環境

### 確認したこと
<!-- スクショや動画を貼っても良い。 -->

- 

### 確認しなかった（できなかった）こと

- 

## その他
