### PR TITLE
feat/#139: 過去のイベントアイテムを削除する機能の実装 & 直近の3個以外のイベントを自動削除する機能の実装

### DIFF
--- a/src/components/Thread/Ogiri/DeleteOgiriModal.jsx
+++ b/src/components/Thread/Ogiri/DeleteOgiriModal.jsx
@@ -1,0 +1,90 @@
+import {
+  Modal,
+  ModalOverlay,
+  ModalContent,
+  ModalHeader,
+  ModalBody,
+  ModalFooter,
+  ModalCloseButton,
+  Button,
+  VStack,
+  Text,
+  Box,
+  Icon,
+} from '@chakra-ui/react';
+import { FiAlertCircle, FiX } from 'react-icons/fi';
+import { PropTypes } from 'prop-types';
+
+const DeleteOgiriEventModal = ({ isOpen, onClose, onDelete, eventTitle }) => {
+  return (
+    <Modal isOpen={isOpen} onClose={onClose}>
+      <ModalOverlay backdropFilter="blur(10px)" />
+      <ModalContent
+        bg="linear-gradient(170deg, rgba(18, 18, 18, 0.95) 0%, rgba(30, 30, 30, 0.95) 100%)"
+        border="1px solid"
+        borderColor="whiteAlpha.200"
+        borderRadius="2xl"
+        p={4}
+        maxW="400px"
+      >
+        <ModalHeader
+          bgGradient="linear(to-r, pink.400, purple.400)"
+          bgClip="text"
+          display="flex"
+          alignItems="center"
+          gap={2}
+        >
+          <Icon as={FiAlertCircle} />
+          大喜利イベントの削除
+        </ModalHeader>
+        <ModalCloseButton color="whiteAlpha.600" />
+
+        <ModalBody color="whiteAlpha.900">
+          <VStack align="stretch" spacing={4}>
+            <Text fontWeight="bold">「{eventTitle}」を削除しますか？</Text>
+            <Box
+              bg="whiteAlpha.100"
+              p={4}
+              borderRadius="xl"
+              fontSize="sm"
+              color="whiteAlpha.800"
+            >
+              <Text>この操作は取り消すことができません。</Text>
+            </Box>
+          </VStack>
+        </ModalBody>
+
+        <ModalFooter gap={3}>
+          <Button
+            onClick={onClose}
+            variant="ghost"
+            color="whiteAlpha.700"
+            _hover={{ bg: 'whiteAlpha.100' }}
+          >
+            キャンセル
+          </Button>
+          <Button
+            onClick={onDelete}
+            bgGradient="linear(to-r, pink.400, purple.400)"
+            color="white"
+            _hover={{
+              bgGradient: 'linear(to-r, pink.500, purple.500)',
+            }}
+            leftIcon={<FiX />}
+          >
+            削除する
+          </Button>
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
+  );
+};
+
+DeleteOgiriEventModal.propTypes = {
+  isOpen: PropTypes.bool.isRequired,
+  onClose: PropTypes.func.isRequired,
+  onDelete: PropTypes.func.isRequired,
+  eventTitle: PropTypes.string.isRequired,
+};
+
+export default DeleteOgiriEventModal;

--- a/src/components/Thread/Ogiri/OgiriEvent.jsx
+++ b/src/components/Thread/Ogiri/OgiriEvent.jsx
@@ -23,7 +23,7 @@ import {
   FiCheck,
   FiChevronUp,
   FiChevronDown,
-  FiTrash2,
+  FiX,
 } from 'react-icons/fi';
 import PropTypes from 'prop-types';
 import { useState, useEffect } from 'react';
@@ -41,9 +41,9 @@ import OgiriAnswers from './OgiriAnswers';
 import { useAlert } from '../../../hooks/useAlert';
 import { collection, query, orderBy, onSnapshot } from 'firebase/firestore';
 import { db } from '../../../config/firebase';
-const MotionBox = motion(Box);
+import DeleteOgiriEventModal from './DeleteOgiriModal';
 
-const OgiriEvent = ({ event, creator, onJoinEvent, currentUser }) => {
+const OgiriEvent = ({ event, creator, onJoinEvent, currentUser, thread }) => {
   const [isParticipating, setIsParticipating] = useState(false);
   const [participantsDetails, setParticipantsDetails] = useState({});
   const [isLoading, setIsLoading] = useState(false);
@@ -56,7 +56,14 @@ const OgiriEvent = ({ event, creator, onJoinEvent, currentUser }) => {
   const [bestAnswerId, setBestAnswerId] = useState(null);
   const { showAlert } = useAlert();
   const [remainingTime, setRemainingTime] = useState('');
-  const isAdmin = currentUser?.uid === event.createdBy;
+  const isAdmin = currentUser?.uid === thread?.createdBy;
+  const { isOpen, onOpen, onClose } = useDisclosure();
+
+  console.log({
+    currentUserId: currentUser?.uid,
+    threadCreatorId: thread?.createdBy,
+    isAdmin,
+  });
 
   useEffect(() => {
     setIsParticipating(event.participants?.includes(currentUser?.uid) || false);
@@ -240,12 +247,19 @@ const OgiriEvent = ({ event, creator, onJoinEvent, currentUser }) => {
     }
   };
 
-  const handleDeleteEvent = async () => {
-    if (!isAdmin) return;
+  const handleDeleteEvent = () => {
+    if (!isAdmin) {
+      showAlert('管理者のみイベントを削除できます', 'error');
+      return;
+    }
+    onOpen();
+  };
 
+  const executeDelete = async () => {
     try {
       await deleteOgiriEvent(event.threadId, event.id);
       showAlert('大喜利イベントを削除しました', 'success');
+      onClose();
     } catch (error) {
       console.error('Error deleting event:', error);
       showAlert('削除に失敗しました', 'error');
@@ -253,323 +267,366 @@ const OgiriEvent = ({ event, creator, onJoinEvent, currentUser }) => {
   };
 
   return (
-    <MotionBox
-      initial={{ opacity: 0, y: -20 }}
-      animate={{ opacity: 1, y: 0 }}
-      transition={{ duration: 0.5 }}
-      bg="linear-gradient(135deg, rgba(18, 18, 18, 0.95) 0%, rgba(30, 30, 30, 0.95) 100%)"
-      backdropFilter="blur(20px)"
-      borderRadius="2xl"
-      border="1px solid"
-      borderColor="whiteAlpha.200"
-      p={6}
-      position="relative"
-      overflow="hidden"
-      _before={{
-        content: '""',
-        position: 'absolute',
-        top: '-50%',
-        left: '-50%',
-        width: '200%',
-        height: '200%',
-        background:
-          'radial-gradient(circle, rgba(255, 20, 147, 0.1) 0%, transparent 70%)',
-        transform: 'rotate(-45deg)',
-        pointerEvents: 'none',
-      }}
-    >
+    <>
       <Box
-        position="absolute"
-        top={0}
-        left={0}
-        right={0}
-        height="2px"
-        bgGradient="linear(to-r, pink.400, purple.500)"
-      />
-
-      <Flex direction="column" gap={6}>
+        position="relative"
+        bg="rgba(0, 0, 0, 0.3)"
+        borderRadius="xl"
+        overflow="hidden"
+        backdropFilter="blur(10px)"
+        boxShadow="0 4px 30px rgba(0, 0, 0, 0.2)"
+        border="1px solid rgba(255, 255, 255, 0.1)"
+        _before={{
+          content: '""',
+          position: 'absolute',
+          top: 0,
+          left: 0,
+          right: 0,
+          height: '2px',
+          bgGradient: 'linear(to-r, pink.500, purple.500)',
+        }}
+      >
         <Flex
           justify="space-between"
           align="center"
-          flexWrap={{ base: 'wrap', md: 'nowrap' }}
-          gap={4}
+          px={4}
+          py={2}
+          borderBottom="1px solid"
+          borderColor="whiteAlpha.100"
+          bg="whiteAlpha.50"
+          position="relative"
+          _after={{
+            content: '""',
+            position: 'absolute',
+            top: 0,
+            left: 0,
+            right: 0,
+            bottom: 0,
+            bgGradient:
+              'linear(to-r, rgba(236, 72, 153, 0.1), rgba(147, 51, 234, 0.1))',
+            pointerEvents: 'none',
+          }}
         >
-          <HStack spacing={4} flex="1">
+          <Flex align="center" gap={2}>
             <Avatar
-              src={creator?.photoURL}
               name={creator?.username}
-              size="md"
-              border="2px solid"
-              borderColor="pink.400"
-              boxShadow="0 0 10px rgba(255, 20, 147, 0.3)"
+              src={creator?.photoURL}
+              size="xs"
             />
-            <VStack align="start" spacing={1}>
-              <Text
-                fontWeight="bold"
-                color="white"
-                fontSize="lg"
-                bgGradient="linear(to-r, pink.200, purple.200)"
-                bgClip="text"
-              >
-                {creator?.username}
-              </Text>
-              <HStack
-                spacing={4}
-                divider={<Box w="1px" h="15px" bg="whiteAlpha.300" />}
-              >
-                <HStack spacing={1}>
-                  <Icon as={FiClock} color="pink.300" />
-                  <Text fontSize="sm" color="whiteAlpha.900">
-                    {remainingTime}
-                  </Text>
-                </HStack>
-                <HStack spacing={1}>
-                  <Icon as={FiUsers} color="purple.300" />
-                  <Text fontSize="sm" color="whiteAlpha.900">
-                    {event.participants?.length || 0}人参加中
-                  </Text>
-                </HStack>
-              </HStack>
-            </VStack>
-          </HStack>
+            <Text fontSize="sm" fontWeight="medium" color="white">
+              {event.title}
+            </Text>
+          </Flex>
 
-          <Flex gap={4} align="center">
-            <AvatarGroup size="sm" max={3}>
-              {Object.values(participantsDetails).map((participant) => (
-                <Avatar
-                  key={participant.uid}
-                  name={participant.username}
-                  src={participant.photoURL}
+          <Flex align="center" gap={2}>
+            {isAdmin && (
+              <motion.div
+                whileHover={{ scale: 1.1 }}
+                whileTap={{ scale: 0.95 }}
+              >
+                <IconButton
+                  icon={<FiX />}
+                  variant="ghost"
                   size="sm"
+                  aria-label="イベントを削除"
+                  onClick={handleDeleteEvent}
+                  bg="transparent"
+                  color="whiteAlpha.800"
+                  _hover={{
+                    bg: 'linear-gradient(135deg, #EC4899 0%, #9333EA 100%)',
+                    color: 'white',
+                    transform: 'translateY(-1px)',
+                    boxShadow: '0 4px 12px rgba(236, 72, 153, 0.3)',
+                  }}
+                  _active={{
+                    transform: 'translateY(0)',
+                    boxShadow: 'none',
+                  }}
+                  rounded="full"
+                  minW="24px"
+                  height="24px"
+                  fontSize="16px"
                 />
-              ))}
-            </AvatarGroup>
-
-            <Button
-              onClick={handleJoinClick}
-              isLoading={isLoading}
-              isDisabled={isExpired}
-              bgGradient={
-                isExpired
-                  ? 'linear(to-r, gray.600, gray.700)'
-                  : isParticipating
-                    ? 'linear(to-r, green.400, teal.400)'
-                    : 'linear(to-r, pink.400, purple.400)'
-              }
-              color={isExpired ? 'whiteAlpha.600' : 'white'}
-              px={6}
-              py={6}
-              fontSize="md"
-              rightIcon={
-                !isExpired && (
-                  <Icon as={isParticipating ? FiCheck : FiArrowRight} />
-                )
-              }
-              _hover={{
-                transform: isExpired ? 'none' : 'translateY(-2px)',
-                boxShadow: isExpired
-                  ? 'none'
-                  : '0 4px 12px rgba(255, 20, 147, 0.3)',
-              }}
-              _active={{
-                transform: isExpired ? 'none' : 'translateY(0)',
-                boxShadow: 'none',
-              }}
-              _disabled={{
-                opacity: 0.7,
-                cursor: 'not-allowed',
-                boxShadow: 'none',
-                _hover: {
-                  bg: 'linear(to-r, gray.600, gray.700)',
-                  transform: 'none',
-                },
-              }}
-              borderRadius="xl"
-              transition="all 0.2s"
-              border="1px solid"
-              borderColor={isExpired ? 'gray.600' : 'transparent'}
-            >
-              {isExpired ? (
-                <HStack spacing={2} opacity={0.8}>
-                  <Icon as={FiClock} />
-                  <Text>終了済み</Text>
-                </HStack>
-              ) : isParticipating ? (
-                '参加中'
-              ) : (
-                '大喜利に参加する'
-              )}
-            </Button>
+              </motion.div>
+            )}
           </Flex>
         </Flex>
 
-        <Box>
-          <Badge
-            colorScheme="pink"
-            mb={3}
-            px={3}
-            py={1}
-            borderRadius="full"
-            textTransform="none"
-            fontSize="sm"
-          >
-            お題
-          </Badge>
-          {event.odaiType === 'text' ? (
-            <Text
-              fontSize="xl"
-              fontWeight="bold"
-              color="white"
-              lineHeight="1.6"
-              px={2}
+        <Box p={6}>
+          <Flex direction="column" gap={6}>
+            <Flex
+              justify="space-between"
+              align="center"
+              flexWrap={{ base: 'wrap', md: 'nowrap' }}
+              gap={4}
             >
-              {event.title}
-            </Text>
-          ) : (
-            <Box
-              borderRadius="xl"
-              overflow="hidden"
-              maxH="400px"
-              position="relative"
-              bg="blackAlpha.400"
-              boxShadow="0 4px 20px rgba(0, 0, 0, 0.2)"
-            >
-              <Image
-                src={event.selectedImage}
-                alt="お題画像"
-                width="100%"
-                height="auto"
-                objectFit="contain"
-                maxH="400px"
-                mx="auto"
-                loading="lazy"
-              />
-            </Box>
-          )}
-        </Box>
+              <HStack spacing={4} flex="1">
+                <Avatar
+                  src={creator?.photoURL}
+                  name={creator?.username}
+                  size="md"
+                  border="2px solid"
+                  borderColor="pink.400"
+                  boxShadow="0 0 10px rgba(255, 20, 147, 0.3)"
+                />
+                <VStack align="start" spacing={1}>
+                  <Text
+                    fontWeight="bold"
+                    color="white"
+                    fontSize="lg"
+                    bgGradient="linear(to-r, pink.200, purple.200)"
+                    bgClip="text"
+                  >
+                    {creator?.username}
+                  </Text>
+                  <HStack
+                    spacing={4}
+                    divider={<Box w="1px" h="15px" bg="whiteAlpha.300" />}
+                  >
+                    <HStack spacing={1}>
+                      <Icon as={FiClock} color="pink.300" />
+                      <Text fontSize="sm" color="whiteAlpha.900">
+                        {remainingTime}
+                      </Text>
+                    </HStack>
+                    <HStack spacing={1}>
+                      <Icon as={FiUsers} color="purple.300" />
+                      <Text fontSize="sm" color="whiteAlpha.900">
+                        {event.participants?.length || 0}人参加中
+                      </Text>
+                    </HStack>
+                  </HStack>
+                </VStack>
+              </HStack>
 
-        {isParticipating && !isExpired && (
-          <Box mt={4}>
-            <Box
-              bg="rgba(0, 0, 0, 0.7)"
-              backdropFilter="blur(20px)"
-              borderRadius="24px"
-              border="1px solid"
-              borderColor="whiteAlpha.200"
-              overflow="hidden"
-              position="relative"
-            >
-              <Box
-                position="absolute"
-                top={0}
-                left={0}
-                right={0}
-                height="2px"
-                bgGradient="linear(to-r, pink.400, purple.500)"
-              />
+              <Flex gap={4} align="center">
+                <AvatarGroup size="sm" max={3}>
+                  {Object.values(participantsDetails).map((participant) => (
+                    <Avatar
+                      key={participant.uid}
+                      name={participant.username}
+                      src={participant.photoURL}
+                      size="sm"
+                    />
+                  ))}
+                </AvatarGroup>
 
-              <Box p={4}>
-                <Textarea
-                  value={answer}
-                  onChange={(e) => setAnswer(e.target.value)}
-                  placeholder="回答を入力..."
-                  bg="whiteAlpha.50"
-                  border="none"
-                  color="white"
-                  fontSize="lg"
-                  height="100px"
-                  py={2}
-                  px={3}
-                  borderRadius="xl"
-                  resize="none"
-                  textAlign="center"
-                  lineHeight="80px" // 100pxから80pxに変更して上に移動
-                  _placeholder={{
-                    color: 'whiteAlpha.500',
-                    textAlign: 'center',
+                <Button
+                  onClick={handleJoinClick}
+                  isLoading={isLoading}
+                  isDisabled={isExpired}
+                  bgGradient={
+                    isExpired
+                      ? 'linear(to-r, gray.600, gray.700)'
+                      : isParticipating
+                        ? 'linear(to-r, green.400, teal.400)'
+                        : 'linear(to-r, pink.400, purple.400)'
+                  }
+                  color={isExpired ? 'whiteAlpha.600' : 'white'}
+                  px={6}
+                  py={6}
+                  fontSize="md"
+                  rightIcon={
+                    !isExpired && (
+                      <Icon as={isParticipating ? FiCheck : FiArrowRight} />
+                    )
+                  }
+                  _hover={{
+                    transform: isExpired ? 'none' : 'translateY(-2px)',
+                    boxShadow: isExpired
+                      ? 'none'
+                      : '0 4px 12px rgba(255, 20, 147, 0.3)',
                   }}
-                  _focus={{
-                    bg: 'whiteAlpha.100',
+                  _active={{
+                    transform: isExpired ? 'none' : 'translateY(0)',
                     boxShadow: 'none',
                   }}
-                  sx={{
-                    '&::-webkit-scrollbar': {
-                      display: 'none',
+                  _disabled={{
+                    opacity: 0.7,
+                    cursor: 'not-allowed',
+                    boxShadow: 'none',
+                    _hover: {
+                      bg: 'linear(to-r, gray.600, gray.700)',
+                      transform: 'none',
                     },
                   }}
-                />
-                <Flex justify="space-between" align="center" mt={2}>
-                  <Text fontSize="sm" color="whiteAlpha.700">
-                    残り{event.maxResponses - userAnswerCount}回回答可能
-                  </Text>
-                  <Button
-                    onClick={handleSubmitAnswer}
-                    isLoading={isSubmitting}
-                    bgGradient="linear(to-r, pink.400, purple.400)"
-                    color="white"
-                    size="sm"
-                    _hover={{
-                      bgGradient: 'linear(to-r, pink.500, purple.500)',
-                      transform: 'translateY(-1px)',
-                    }}
-                    isDisabled={
-                      !answer.trim() ||
-                      userAnswerCount >= event.maxResponses ||
-                      isExpired
-                    }
-                  >
-                    回答する
-                  </Button>
-                </Flex>
-              </Box>
+                  borderRadius="xl"
+                  transition="all 0.2s"
+                  border="1px solid"
+                  borderColor={isExpired ? 'gray.600' : 'transparent'}
+                >
+                  {isExpired ? (
+                    <HStack spacing={2} opacity={0.8}>
+                      <Icon as={FiClock} />
+                      <Text>終了済み</Text>
+                    </HStack>
+                  ) : isParticipating ? (
+                    '参加中'
+                  ) : (
+                    '大喜利に参加する'
+                  )}
+                </Button>
+              </Flex>
+            </Flex>
+
+            <Box>
+              <Badge
+                colorScheme="pink"
+                mb={3}
+                px={3}
+                py={1}
+                borderRadius="full"
+                textTransform="none"
+                fontSize="sm"
+              >
+                お題
+              </Badge>
+              {event.odaiType === 'text' ? (
+                <Text
+                  fontSize="xl"
+                  fontWeight="bold"
+                  color="white"
+                  lineHeight="1.6"
+                  px={2}
+                >
+                  {event.title}
+                </Text>
+              ) : (
+                <Box
+                  borderRadius="xl"
+                  overflow="hidden"
+                  maxH="400px"
+                  position="relative"
+                  bg="blackAlpha.400"
+                  boxShadow="0 4px 20px rgba(0, 0, 0, 0.2)"
+                >
+                  <Image
+                    src={event.selectedImage}
+                    alt="お題画像"
+                    width="100%"
+                    height="auto"
+                    objectFit="contain"
+                    maxH="400px"
+                    mx="auto"
+                    loading="lazy"
+                  />
+                </Box>
+              )}
             </Box>
-          </Box>
-        )}
 
-        <Box mt={4}>
-          <Button
-            onClick={toggleAnswers}
-            variant="ghost"
-            color="whiteAlpha.800"
-            width="100%"
-            rightIcon={
-              <Icon as={isAnswersOpen ? FiChevronUp : FiChevronDown} />
-            }
-          >
-            回答を{isAnswersOpen ? '閉じる' : '見る'}
-          </Button>
-          <Collapse in={isAnswersOpen}>
-            <VStack spacing={4} mt={4}>
-              <OgiriAnswers
-                answers={answers}
-                currentUser={currentUser}
-                onLike={handleLike}
-                bestAnswerId={bestAnswerId}
-                isExpired={isExpired}
-              />
-            </VStack>
-          </Collapse>
+            {isParticipating && !isExpired && (
+              <Box mt={4}>
+                <Box
+                  bg="rgba(0, 0, 0, 0.7)"
+                  backdropFilter="blur(20px)"
+                  borderRadius="24px"
+                  border="1px solid"
+                  borderColor="whiteAlpha.200"
+                  overflow="hidden"
+                  position="relative"
+                >
+                  <Box
+                    position="absolute"
+                    top={0}
+                    left={0}
+                    right={0}
+                    height="2px"
+                    bgGradient="linear(to-r, pink.400, purple.500)"
+                  />
+
+                  <Box p={4}>
+                    <Textarea
+                      value={answer}
+                      onChange={(e) => setAnswer(e.target.value)}
+                      placeholder="回答を入力..."
+                      bg="whiteAlpha.50"
+                      border="none"
+                      color="white"
+                      fontSize="lg"
+                      height="100px"
+                      py={2}
+                      px={3}
+                      borderRadius="xl"
+                      resize="none"
+                      textAlign="center"
+                      lineHeight="80px"
+                      _placeholder={{
+                        color: 'whiteAlpha.500',
+                        textAlign: 'center',
+                      }}
+                      _focus={{
+                        bg: 'whiteAlpha.100',
+                        boxShadow: 'none',
+                      }}
+                      sx={{
+                        '&::-webkit-scrollbar': {
+                          display: 'none',
+                        },
+                      }}
+                    />
+                    <Flex justify="space-between" align="center" mt={2}>
+                      <Text fontSize="sm" color="whiteAlpha.700">
+                        残り{event.maxResponses - userAnswerCount}回回答可能
+                      </Text>
+                      <Button
+                        onClick={handleSubmitAnswer}
+                        isLoading={isSubmitting}
+                        bgGradient="linear(to-r, pink.400, purple.400)"
+                        color="white"
+                        size="sm"
+                        _hover={{
+                          bgGradient: 'linear(to-r, pink.500, purple.500)',
+                          transform: 'translateY(-1px)',
+                        }}
+                        isDisabled={
+                          !answer.trim() ||
+                          userAnswerCount >= event.maxResponses ||
+                          isExpired
+                        }
+                      >
+                        回答する
+                      </Button>
+                    </Flex>
+                  </Box>
+                </Box>
+              </Box>
+            )}
+
+            <Box mt={4}>
+              <Button
+                onClick={toggleAnswers}
+                variant="ghost"
+                color="whiteAlpha.800"
+                width="100%"
+                rightIcon={
+                  <Icon as={isAnswersOpen ? FiChevronUp : FiChevronDown} />
+                }
+              >
+                回答を{isAnswersOpen ? '閉じる' : '見る'}
+              </Button>
+              <Collapse in={isAnswersOpen}>
+                <VStack spacing={4} mt={4}>
+                  <OgiriAnswers
+                    answers={answers}
+                    currentUser={currentUser}
+                    onLike={handleLike}
+                    bestAnswerId={bestAnswerId}
+                    isExpired={isExpired}
+                  />
+                </VStack>
+              </Collapse>
+            </Box>
+          </Flex>
         </Box>
+      </Box>
 
-        {isAdmin && isExpired && (
-          <IconButton
-            icon={<FiTrash2 />}
-            variant="ghost"
-            colorScheme="red"
-            size="sm"
-            onClick={handleDeleteEvent}
-            aria-label="イベントを削除"
-            position="absolute"
-            top={4}
-            right={4}
-            _hover={{
-              bg: 'red.500',
-              color: 'white',
-            }}
-          />
-        )}
-      </Flex>
-    </MotionBox>
+      <DeleteOgiriEventModal
+        isOpen={isOpen}
+        onClose={onClose}
+        onDelete={executeDelete}
+        eventTitle={event.title}
+      />
+    </>
   );
 };
 
@@ -593,6 +650,7 @@ OgiriEvent.propTypes = {
   creator: PropTypes.object.isRequired,
   onJoinEvent: PropTypes.func.isRequired,
   currentUser: PropTypes.object,
+  thread: PropTypes.object,
 };
 
 export default OgiriEvent;


### PR DESCRIPTION
## 対応する Issue

<!-- 該当の Issue を Close したくない場合は、 `Closes` の文言を削除する。 -->
Closes #139 

## リンク

<!-- 参考にしたサイト等があれば記載する。 -->

## やったこと

- 過去のイベントがスタックしていくとメッセージセクションが見づらくなってしまうので、管理者のみイベントセクションを削除できるように実装
- 直近の3個のイベントのみを表示し、それより前のイベントは自動で削除するように実装

## やらなかったこと

- 

## ユーザーへの影響

<!-- ユーザーから見て、できるようになったことやできなくなったこと等を記載する。 -->

## 動作確認

### 確認した環境

### 確認したこと
<!-- スクショや動画を貼っても良い。 -->

- 

### 確認しなかった（できなかった）こと

- 

## その他
