### PR TITLE
feat/#148: ✨ OgiriEventコンポーネントにキーボードショートカット機能を追加し、MacとWindowsでの送信方法を明示

### DIFF
--- a/src/components/Thread/Ogiri/OgiriEvent.jsx
+++ b/src/components/Thread/Ogiri/OgiriEvent.jsx
@@ -58,6 +58,7 @@ const OgiriEvent = ({ event, creator, onJoinEvent, currentUser, thread }) => {
   const [remainingTime, setRemainingTime] = useState('');
   const isAdmin = currentUser?.uid === thread?.createdBy;
   const { isOpen, onOpen, onClose } = useDisclosure();
+  const isMac = /Mac|iPod|iPhone|iPad/.test(navigator.platform);
 
   console.log({
     currentUserId: currentUser?.uid,
@@ -263,6 +264,13 @@ const OgiriEvent = ({ event, creator, onJoinEvent, currentUser, thread }) => {
     } catch (error) {
       console.error('Error deleting event:', error);
       showAlert('削除に失敗しました', 'error');
+    }
+  };
+
+  const handleKeyPress = (e) => {
+    if (e.key === 'Enter' && ((isMac && e.metaKey) || (!isMac && e.ctrlKey))) {
+      e.preventDefault();
+      handleSubmitAnswer();
     }
   };
 
@@ -538,7 +546,8 @@ const OgiriEvent = ({ event, creator, onJoinEvent, currentUser, thread }) => {
                     <Textarea
                       value={answer}
                       onChange={(e) => setAnswer(e.target.value)}
-                      placeholder="回答を入力..."
+                      onKeyDown={handleKeyPress}
+                      placeholder={`回答を入力... (${isMac ? 'Cmd' : 'Ctrl'} + Enterで送信)`}
                       bg="whiteAlpha.50"
                       border="none"
                       color="white"


### PR DESCRIPTION
## 対応する Issue

<!-- 該当の Issue を Close したくない場合は、 `Closes` の文言を削除する。 -->
Closes #148 

## リンク

<!-- 参考にしたサイト等があれば記載する。 -->

## やったこと

- 大喜利の回答の際にOSに従ってキーボードコマンドを使って送信できるように実装

## やらなかったこと

- 

## ユーザーへの影響

<!-- ユーザーから見て、できるようになったことやできなくなったこと等を記載する。 -->

## 動作確認

### 確認した環境

### 確認したこと
<!-- スクショや動画を貼っても良い。 -->

- 

### 確認しなかった（できなかった）こと

- 

## その他
