### PR TITLE
style/#159:CreateNewThreadにあるModalCloseButtonの色を変更

### DIFF
--- a/src/components/Thread/CreateThreadModal.jsx
+++ b/src/components/Thread/CreateThreadModal.jsx
@@ -188,7 +188,7 @@ const CreateThreadModal = ({ isOpen, onClose, onThreadCreated }) => {
             Create New Thread
           </Heading>
         </ModalHeader>
-        <ModalCloseButton />
+        <ModalCloseButton color = 'whiteAlpha.700'/>
 
         <ModalBody>
           <VStack spacing={{ base: 6, md: 8 }} align="stretch">


### PR DESCRIPTION
## 対応する Issue
#159 style: CreateNewThreadのバツマークの色が見えずらい。
<!-- 該当の Issue を Close したくない場合は、 `Closes` の文言を削除する。 -->
Closes #159

## リンク

<!-- 参考にしたサイト等があれば記載する。 -->

## やったこと

- CreateNewThreadにあるModalCloseButtonの色をwhiteAlpha.700に変更

## やらなかったこと

- 

## ユーザーへの影響

<!-- ユーザーから見て、できるようになったことやできなくなったこと等を記載する。 -->

## 動作確認

### 確認した環境

### 確認したこと
<!-- スクショや動画を貼っても良い。 -->

- ![スクリーンショット 2025-01-10 104503](https://github.com/user-attachments/assets/6b4ff675-9708-46df-a038-5725d27a322f)


### 確認しなかった（できなかった）こと

- 

## その他
