### PR TITLE
feat/#30: ✨ スレッド作成時にスレ主が自由にルールを設定できる機能の実装

### DIFF
--- a/src/components/Thread/CreateThreadModal.jsx
+++ b/src/components/Thread/CreateThreadModal.jsx
@@ -17,6 +17,8 @@ import {
   useToast,
   FormLabel,
   Icon,
+  IconButton,
+  Flex,
 } from '@chakra-ui/react';
 import { motion } from 'framer-motion';
 import {
@@ -25,6 +27,9 @@ import {
   FiPaperclip,
   FiMessageSquare,
   FiUpload,
+  FiShield,
+  FiPlus,
+  FiX,
 } from 'react-icons/fi';
 import PropTypes from 'prop-types';
 
@@ -310,41 +315,37 @@ const CreateThreadModal = ({ isOpen, onClose, onThreadCreated }) => {
               />
             </FormSection>
 
-            <FormSection icon={FiHash} label="Rules">
-              {rules.map((rule, index) => (
-                <Box key={index} marginBottom={4}>
-                  <Input
-                    placeholder="ルールを入力してください"
-                    value={rule}
-                    onChange={(e) => handleRuleChange(index, e.target.value)}
-                    {...inputStyles}
-                  />
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    onClick={() => handleRemoveRule(index)}
-                    color="whiteAlpha.700"
-                    _hover={{
-                      bg: 'whiteAlpha.100',
-                      color: 'white',
-                    }}
-                  >
-                    削除
-                  </Button>
-                </Box>
-              ))}
-              <Button
-                variant="ghost"
-                size="sm"
-                onClick={handleAddRule}
-                color="whiteAlpha.700"
-                _hover={{
-                  bg: 'whiteAlpha.100',
-                  color: 'white',
-                }}
-              >
-                ルールを追加
-              </Button>
+            <FormSection icon={FiShield} label="スレッドルール">
+              <VStack spacing={3} align="stretch">
+                {rules.map((rule, index) => (
+                  <Flex key={index} gap={2}>
+                    <Input
+                      placeholder={`ルール ${index + 1}`}
+                      value={rule}
+                      onChange={(e) => handleRuleChange(index, e.target.value)}
+                      bg="blackAlpha.400"
+                      color="white"
+                      borderRadius="xl"
+                    />
+                    <IconButton
+                      icon={<FiX />}
+                      onClick={() => handleRemoveRule(index)}
+                      variant="ghost"
+                      colorScheme="red"
+                      isDisabled={rules.length === 1}
+                    />
+                  </Flex>
+                ))}
+                <Button
+                  leftIcon={<FiPlus />}
+                  onClick={handleAddRule}
+                  variant="ghost"
+                  size="sm"
+                  w="fit-content"
+                >
+                  ルールを追加
+                </Button>
+              </VStack>
             </FormSection>
           </VStack>
         </ModalBody>

--- a/src/components/Thread/CreateThreadModal.jsx
+++ b/src/components/Thread/CreateThreadModal.jsx
@@ -27,7 +27,6 @@ import {
   FiUpload,
 } from 'react-icons/fi';
 import PropTypes from 'prop-types';
-import { createThread } from '../../services/threadService';
 
 // Motion components
 const MotionInput = motion(Input);
@@ -58,21 +57,23 @@ const inputStyles = {
 
 const FormSection = ({ icon, label, children }) => (
   <Box
-    marginBottom={{ base: 4, md: 5 }}  // セクション間の余白を増加
+    marginBottom={{ base: 4, md: 5 }} // セクション間の余白を増加
   >
     <FormLabel
       color="whiteAlpha.700"
       fontSize={{ base: 'sm', md: 'md' }}
       fontWeight="medium"
-      mb={3}  // ラベルとコンテンツの間隔を増加
+      mb={3} // ラベルとコンテンツの間隔を増加
       display="flex"
       alignItems="center"
-      gap={3}  // アイコンとラベルの間隔を増加
+      gap={3} // アイコンとラベルの間隔を増加
     >
-      <Icon as={icon} boxSize={5} />  {/*アイコンサイズを調整*/}
+      <Icon as={icon} boxSize={5} /> {/*アイコンサイズを調整*/}
       {label}
     </FormLabel>
-    <Box paddingX={2}>  {/*子要素に左右のパディングを追加*/}
+    <Box paddingX={2}>
+      {' '}
+      {/*子要素に左右のパディングを追加*/}
       {children}
     </Box>
   </Box>
@@ -85,17 +86,33 @@ const CreateThreadModal = ({ isOpen, onClose, onThreadCreated }) => {
   const [attachments, setAttachments] = useState([]);
   const toast = useToast();
   const [inputValue, setInputValue] = useState('');
+  const [rules, setRules] = useState(['']);
 
   const MAX_TITLE_LENGTH = 30;
   const MAX_TAG_LENGTH = 30;
   const MAX_TAGS_COUNT = 5;
 
+  const handleAddRule = () => {
+    setRules([...rules, '']);
+  };
+
+  const handleRuleChange = (index, value) => {
+    const newRules = [...rules];
+    newRules[index] = value;
+    setRules(newRules);
+  };
+
+  const handleRemoveRule = (index) => {
+    setRules(rules.filter((_, i) => i !== index));
+  };
+
   const handleCreateThread = async () => {
     // タイトルが空または文字数超過の場合のエラーチェックを追加
-    if (!title || title.length > MAX_TITLE_LENGTH) { // 変更
+    if (!title || title.length > MAX_TITLE_LENGTH) {
+      // 変更
       toast({
         title: 'エラー',
-        description: `タイトルは１文字以上${MAX_TITLE_LENGTH}文字以下にしてください。`, // 変更
+        description: `タイトルは１文字以上${MAX_TITLE_LENGTH}文字以下にしてください。`,
         status: 'error',
         duration: 3000,
         isClosable: true,
@@ -117,7 +134,7 @@ const CreateThreadModal = ({ isOpen, onClose, onThreadCreated }) => {
     }
     //タグ文字数
     //2. 各タグの文字数をチェック、filterで30文字超のタグを抽出。１つでも存在すればエラー。
-    const longTags = tags.filter(tag => tag.length > MAX_TAG_LENGTH);
+    const longTags = tags.filter((tag) => tag.length > MAX_TAG_LENGTH);
     if (longTags.length > 0) {
       toast({
         title: 'エラー',
@@ -140,9 +157,20 @@ const CreateThreadModal = ({ isOpen, onClose, onThreadCreated }) => {
       return;
     }
 
+    const validRules = rules.filter((rule) => rule.trim() !== '');
+
     try {
-      await createThread(title, content, tags, attachments);
-      await onThreadCreated();
+      const threadData = {
+        title,
+        content,
+        tags,
+        attachments,
+        rules: validRules,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+
+      await onThreadCreated(threadData);
       toast({
         title: '作成完了',
         description: 'スレッドが作成されました。',
@@ -154,6 +182,7 @@ const CreateThreadModal = ({ isOpen, onClose, onThreadCreated }) => {
       setContent('');
       setTags([]);
       setAttachments([]);
+      setRules(['']);
       onClose();
     } catch (err) {
       toast({
@@ -175,42 +204,40 @@ const CreateThreadModal = ({ isOpen, onClose, onThreadCreated }) => {
         borderColor="whiteAlpha.200"
         borderRadius="2xl"
         boxShadow="0 8px 32px 0 rgba(236, 72, 153, 0.37), 0 8px 32px 0 rgba(128, 90, 213, 0.37)"
-        px={{ base: 6, md: 10 }}  //左右のパディングを増加
-        py={{ base: 6, md: 8 }}  //上下のパディングを増加
-        maxW={{ base: "95%", md: "800px" }} //最大値を設定
+        px={{ base: 6, md: 10 }} //左右のパディングを増加
+        py={{ base: 6, md: 8 }} //上下のパディングを増加
+        maxW={{ base: '95%', md: '800px' }} //最大値を設定
         mx="auto" //中央寄せ
       >
         <ModalHeader>
           <VStack spacing={1} align="center" width="100%">
             <Heading
-              size={{ base: "2xl", md: "2xl" }}  // サイズを大きく設定
+              size={{ base: '2xl', md: '2xl' }} // サイズを大きく設定
               bgGradient="linear(to-r, pink.400, purple.400)"
               bgClip="text"
               fontWeight="extrabold"
               letterSpacing="tight"
               display="flex"
               alignItems="center"
-              justifyContent="center"  // 中央揃えを追加
+              justifyContent="center" // 中央揃えを追加
               marginBottom={{ base: 4, md: 8 }}
               gap={3}
-              width="100%"  // 幅を100%に設定
+              width="100%" // 幅を100%に設定
             >
-              <Icon as={FiEdit3} boxSize={1}/>
+              <Icon as={FiEdit3} boxSize={1} />
               Create New Thread
             </Heading>
-            <Text
-              color={"whiteAlpha.700"}
-              textAlign="center"
-            >
+            <Text color={'whiteAlpha.700'} textAlign="center">
               あなただけのスレッドを作ろう！✨
             </Text>
           </VStack>
         </ModalHeader>
         <ModalCloseButton
-          color='whiteAlpha.700'
+          color="whiteAlpha.700"
           marginTop={{ base: 4, md: 8 }}
           marginRight={{ base: 4, md: 4 }}
-          fontSize={25} />
+          fontSize={25}
+        />
 
         <ModalBody>
           <VStack spacing={{ base: 6, md: 8 }} align="stretch">
@@ -246,8 +273,8 @@ const CreateThreadModal = ({ isOpen, onClose, onThreadCreated }) => {
                   // タグの処理
                   const newTags = currentInput
                     .split(',')
-                    .map(tag => tag.trim())
-                    .filter(tag => tag !== '')
+                    .map((tag) => tag.trim())
+                    .filter((tag) => tag !== '');
                   setTags(newTags);
                 }}
                 {...inputStyles}
@@ -256,23 +283,24 @@ const CreateThreadModal = ({ isOpen, onClose, onThreadCreated }) => {
               <Text
                 color={
                   tags.length >= MAX_TAGS_COUNT ? 'red.400' : 'whiteAlpha.700'
-                } // 追加 
+                } // 追加
                 mt={2}
                 fontSize="sm"
                 textAlign="right"
               >
                 {tags.length}/5
               </Text>
-
-            </FormSection>
-
-            <FormSection icon={FiPaperclip} marginTop={{ base: 4, md: 8 }} label="Attachments">
-              <FileUploadBox setAttachments={setAttachments} />
             </FormSection>
 
             <FormSection
-              icon={FiMessageSquare}
-              label="Thread Content">
+              icon={FiPaperclip}
+              marginTop={{ base: 4, md: 8 }}
+              label="Attachments"
+            >
+              <FileUploadBox setAttachments={setAttachments} />
+            </FormSection>
+
+            <FormSection icon={FiMessageSquare} label="Thread Content">
               <MotionTextarea
                 placeholder="スレッドの内容を入力してください"
                 value={content}
@@ -280,6 +308,43 @@ const CreateThreadModal = ({ isOpen, onClose, onThreadCreated }) => {
                 rows={10}
                 {...inputStyles}
               />
+            </FormSection>
+
+            <FormSection icon={FiHash} label="Rules">
+              {rules.map((rule, index) => (
+                <Box key={index} marginBottom={4}>
+                  <Input
+                    placeholder="ルールを入力してください"
+                    value={rule}
+                    onChange={(e) => handleRuleChange(index, e.target.value)}
+                    {...inputStyles}
+                  />
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => handleRemoveRule(index)}
+                    color="whiteAlpha.700"
+                    _hover={{
+                      bg: 'whiteAlpha.100',
+                      color: 'white',
+                    }}
+                  >
+                    削除
+                  </Button>
+                </Box>
+              ))}
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={handleAddRule}
+                color="whiteAlpha.700"
+                _hover={{
+                  bg: 'whiteAlpha.100',
+                  color: 'white',
+                }}
+              >
+                ルールを追加
+              </Button>
             </FormSection>
           </VStack>
         </ModalBody>

--- a/src/components/Thread/JoinThreadModal.jsx
+++ b/src/components/Thread/JoinThreadModal.jsx
@@ -1,0 +1,142 @@
+import {
+  Modal,
+  ModalOverlay,
+  ModalContent,
+  ModalHeader,
+  ModalBody,
+  ModalFooter,
+  Button,
+  VStack,
+  Text,
+  Checkbox,
+  Box,
+  Icon,
+  useToast,
+} from '@chakra-ui/react';
+import { FiAlertCircle } from 'react-icons/fi';
+import { useState } from 'react';
+import PropTypes from 'prop-types';
+
+const JoinThreadModal = ({ isOpen, onClose, thread, onJoin }) => {
+  const [agreedRules, setAgreedRules] = useState({});
+  const toast = useToast();
+
+  const handleCheckRule = (index) => {
+    setAgreedRules((prev) => ({
+      ...prev,
+      [index]: !prev[index],
+    }));
+  };
+
+  const handleJoin = async () => {
+    if (!allRulesAgreed) {
+      toast({
+        title: 'エラー',
+        description: 'すべてのルールに同意する必要があります。',
+        status: 'error',
+        duration: 3000,
+        isClosable: true,
+      });
+      return;
+    }
+    await onJoin();
+    onClose();
+  };
+
+  const allRulesAgreed = thread?.rules?.every((_, index) => agreedRules[index]);
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      isCentered
+      motionPreset="slideInBottom"
+    >
+      <ModalOverlay backdropFilter="blur(10px)" />
+      <ModalContent
+        bg="linear-gradient(170deg, rgba(18, 18, 18, 0.95) 0%, rgba(30, 30, 30, 0.95) 100%)"
+        border="1px solid"
+        borderColor="whiteAlpha.200"
+        borderRadius="2xl"
+        p={4}
+      >
+        <ModalHeader display="flex" alignItems="center" gap={2}>
+          <Icon as={FiAlertCircle} color="pink.400" />
+          <Text bgGradient="linear(to-r, pink.400, purple.400)" bgClip="text">
+            スレッドに参加
+          </Text>
+        </ModalHeader>
+
+        <ModalBody>
+          <VStack spacing={6} align="stretch">
+            <Text fontWeight="bold" color="white">
+              「{thread?.title}」に参加しますか？
+            </Text>
+
+            <Box
+              bg="whiteAlpha.50"
+              p={4}
+              borderRadius="xl"
+              border="1px solid"
+              borderColor="whiteAlpha.100"
+            >
+              <Text fontWeight="bold" mb={4} color="white">
+                スレッドのルール
+              </Text>
+              <VStack align="start" spacing={3}>
+                {thread?.rules?.map((rule, index) => (
+                  <Checkbox
+                    key={index}
+                    isChecked={agreedRules[index]}
+                    onChange={() => handleCheckRule(index)}
+                    colorScheme="pink"
+                  >
+                    <Text color="whiteAlpha.900">{rule}</Text>
+                  </Checkbox>
+                ))}
+              </VStack>
+            </Box>
+          </VStack>
+        </ModalBody>
+
+        <ModalFooter gap={3}>
+          <Button
+            variant="ghost"
+            onClick={onClose}
+            color="whiteAlpha.600"
+            _hover={{ bg: 'whiteAlpha.100' }}
+          >
+            キャンセル
+          </Button>
+          <Button
+            onClick={handleJoin}
+            bgGradient="linear(to-r, pink.400, purple.400)"
+            color="white"
+            isDisabled={!allRulesAgreed}
+            _hover={{
+              bgGradient: 'linear(to-r, pink.500, purple.500)',
+            }}
+            _disabled={{
+              opacity: 0.6,
+              cursor: 'not-allowed',
+            }}
+          >
+            同意して参加する
+          </Button>
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
+  );
+};
+
+JoinThreadModal.propTypes = {
+  isOpen: PropTypes.bool.isRequired,
+  onClose: PropTypes.func.isRequired,
+  thread: PropTypes.shape({
+    title: PropTypes.string.isRequired,
+    rules: PropTypes.arrayOf(PropTypes.string),
+  }),
+  onJoin: PropTypes.func.isRequired,
+};
+
+export default JoinThreadModal;

--- a/src/components/Thread/ThreadList.jsx
+++ b/src/components/Thread/ThreadList.jsx
@@ -9,13 +9,6 @@ import {
   Tag,
   Icon,
   Button,
-  Modal,
-  ModalOverlay,
-  ModalContent,
-  ModalHeader,
-  ModalFooter,
-  ModalBody,
-  ModalCloseButton,
   useDisclosure,
   Flex,
 } from '@chakra-ui/react';
@@ -26,11 +19,10 @@ import {
   FiMessageCircle,
   FiUser,
   FiUserPlus,
-  FiCheckCircle,
-  FiAlertCircle,
 } from 'react-icons/fi';
 import { auth } from '../../config/firebase';
 import PropTypes from 'prop-types';
+import JoinThreadModal from './JoinThreadModal';
 
 const MotionBox = motion(Box);
 const MotionTag = motion(Tag);
@@ -264,75 +256,12 @@ function ThreadList({
         ))}
       </VStack>
 
-      {/* モーダル部分は以前と同じ */}
-      <Modal
+      <JoinThreadModal
         isOpen={isOpen}
         onClose={onClose}
-        isCentered
-        motionPreset="slideInBottom"
-      >
-        {/* モーダルの内容は変更なし */}
-        <ModalOverlay backdropFilter="blur(10px)" />
-        <ModalContent
-          bg="linear-gradient(170deg, rgba(18, 18, 18, 0.95) 0%, rgba(30, 30, 30, 0.95) 100%)"
-          border="1px solid"
-          borderColor="whiteAlpha.200"
-          borderRadius="2xl"
-          p={4}
-        >
-          {/* モーダルヘッダー、ボディ、フッターは以前と同じ */}
-          <ModalHeader
-            bgGradient="linear(to-r, pink.400, purple.400)"
-            bgClip="text"
-            display="flex"
-            alignItems="center"
-            gap={2}
-          >
-            <Icon as={FiAlertCircle} />
-            スレッド参加の確認
-          </ModalHeader>
-          <ModalCloseButton color="whiteAlpha.600" />
-          <ModalBody color="whiteAlpha.900">
-            <VStack align="stretch" spacing={4}>
-              <Text fontWeight="bold">
-                「{selectedThread?.title}」に参加しますか？
-              </Text>
-              <Box
-                bg="whiteAlpha.100"
-                p={4}
-                borderRadius="xl"
-                fontSize="sm"
-                color="whiteAlpha.800"
-              >
-                <Text fontWeight="bold" mb={2}>
-                  スレッドのルール
-                </Text>
-                <VStack align="start" spacing={2}>
-                  <Text>• 参加者への敬意を持った発言を心がけてください</Text>
-                  <Text>• 不適切な発言や画像の投稿は禁止です</Text>
-                  <Text>• 話題に関係のない投稿は控えめにお願いします</Text>
-                </VStack>
-              </Box>
-            </VStack>
-          </ModalBody>
-          <ModalFooter gap={3}>
-            <Button variant="ghost" onClick={onClose} color="whiteAlpha.600">
-              キャンセル
-            </Button>
-            <Button
-              onClick={handleJoinConfirm}
-              bgGradient="linear(to-r, pink.400, purple.400)"
-              color="white"
-              leftIcon={<Icon as={FiCheckCircle} />}
-              _hover={{
-                bgGradient: 'linear(to-r, pink.500, purple.500)',
-              }}
-            >
-              参加する
-            </Button>
-          </ModalFooter>
-        </ModalContent>
-      </Modal>
+        thread={selectedThread}
+        onJoin={handleJoinConfirm}
+      />
     </>
   );
 }

--- a/src/components/ui/Sidebar.jsx
+++ b/src/components/ui/Sidebar.jsx
@@ -29,6 +29,17 @@ function Sidebar({ isOpen, toggleSidebar }) {
   const { logout } = useAuth();
   const { isOpen: isCreateThreadModalOpen, onOpen, onClose } = useDisclosure();
 
+  const handleThreadCreated = async (threadId) => {
+    try {
+      // 少し遅延を入れてからナビゲーションを実行
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+      onClose();
+      navigate(`/thread/${threadId}`);
+    } catch (error) {
+      console.error('Navigation error:', error);
+    }
+  };
+
   const handleNavigation = (path) => {
     if (path === '/logout') {
       logout();
@@ -214,7 +225,11 @@ function Sidebar({ isOpen, toggleSidebar }) {
         </Box>
       </MotionBox>
 
-      <CreateThreadModal isOpen={isCreateThreadModalOpen} onClose={onClose} />
+      <CreateThreadModal
+        isOpen={isCreateThreadModalOpen}
+        onClose={onClose}
+        onThreadCreated={handleThreadCreated}
+      />
     </>
   );
 }

--- a/src/services/threadService.js
+++ b/src/services/threadService.js
@@ -14,7 +14,13 @@ import { auth } from '../config/firebase';
 
 const threadsCollection = collection(db, 'threads');
 
-export const createThread = async (title, content, tags, attachments) => {
+export const createThread = async (
+  title,
+  content,
+  tags,
+  attachments,
+  rules = []
+) => {
   try {
     const user = auth.currentUser;
     const docRef = await addDoc(threadsCollection, {
@@ -22,6 +28,7 @@ export const createThread = async (title, content, tags, attachments) => {
       content,
       tags,
       attachments,
+      rules,
       createdAt: new Date(),
       createdBy: user ? user.uid : 'anonymous',
       comments: [],


### PR DESCRIPTION
## 対応する Issue

<!-- 該当の Issue を Close したくない場合は、 `Closes` の文言を削除する。 -->
Closes #30 

## リンク

<!-- 参考にしたサイト等があれば記載する。 -->

## やったこと
### スレッド作成機能の拡張
- スレッド作成時のルール設定機能を追加
   - ルールの追加、編集、削除機能を実装
   - createThread関数にrules引数を追加
   - Ctrl/Cmd + Enterでのルール追加機能
   - 追加ボタンによるルール登録機能
   - エラーハンドリングの実装
- スレッド参加機能の実装
   - JoinThreadModalコンポーネントを新規作成
   - スレッド参加時のルール確認機能
   - ルール同意機能の追加
   - スレッド作成後の自動遷移機能
- コードの最適化
   - モーダル関連コードの整理
   - 不要なインポートの削除
   - バリデーション処理の追加
## やらなかったこと
- スレッドルールの文字数制限
- ルールの並び替え機能
- ルールのインポート/エクスポート機能

## ユーザーへの影響

<!-- ユーザーから見て、できるようになったことやできなくなったこと等を記載する。 -->

- スレッド作成時にカスタムルールを設定可能に
- スレッド参加時にルールの確認と同意が必要に
- より直感的なUI/UXでルールの追加が可能に

## 動作確認

### 確認した環境

- OS: macOS Sequoia
ブラウザ: Arc Browser, Chrome
画面サイズ: デスクトップ

### 確認したこと
<!-- スクショや動画を貼っても良い。 -->

- スレッド作成時のルール追加機能
   - 通常の入力
   - Ctrl/Cmd + Enterでの追加
   - 追加ボタンでの追加
   - 空文字のバリデーション
- スレッド参加時のルール確認
   - ルール同意前の参加ボタン無効化
   - 全ルール同意後の参加処理

### 確認しなかった（できなかった）こと

- 大量のルール（10個以上）を設定した場合の表示

## その他
- アニメーションやトランジション効果は必要に応じて調整可能
- 今後のアップデートでルールの文字数制限や並び替え機能を追加予定